### PR TITLE
Add hacker-news-groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A collection of awesome Hacker News apps, libraries, resources and shiny things.
 	- [Alfred workflows](#alfred-workflows)
 	- [SMS](#sms)
 	- [Smart watch](#smart-watch)
+- [Resources](#resources)
 - [Contributing](#contributing)
 
 ## Apps
@@ -304,6 +305,10 @@ A collection of awesome Hacker News apps, libraries, resources and shiny things.
 ### Smart watch
 
 - <https://github.com/luisivan/pebble-hn> by [Luis Iván Cuende](https://github.com/luisivan)
+
+## Resources
+
+- [hacker-news-groups](https://github.com/antontarasenko/hacker-news-groups) by [Anton Tarasenko](https://github.com/antontarasenko)
 
 ## Contributing
 


### PR DESCRIPTION
I suggest adding [hacker-news-groups](https://github.com/antontarasenko/hacker-news-groups), a list of meetups and online communities of HN readers, which I maintain.

Also, I've added the section "Resources".