### PR TITLE
Updated MacOS section for accuracy (no newly added items)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,10 +196,10 @@ A collection of awesome Hacker News apps, libraries, resources and shiny things.
 
 ### Mac OS
 
-- [Hacker Bar](http://hackerbarapp.com/) by [Mark Rickert](https://github.com/markrickert)
-- [MackerNews](https://itunes.apple.com/us/app/mackernews-hacker-news-client/id946730699?mt=12) by [Haris Amin](https://github.com/hamin)
 - [Hacker Menu](https://hackermenu.io/) by [Jingwen Owen Ou](https://github.com/jingweno)
 - [touchHNews](https://github.com/mrmekon/toucHNews) - Hacker News (YCombinator) news feed for the Mac Touch Bar
+- [MackerNews](https://itunes.apple.com/us/app/mackernews-hacker-news-client/id946730699?mt=12) by [Haris Amin](https://github.com/hamin) (Not available in U.S.)
+- ~~[Hacker Bar](http://hackerbarapp.com/) by [Mark Rickert](https://github.com/markrickert)~~
 - ~~<http://www.guidefreitas.com/hacker-news-menubar-osx/> by Guilherme Juraszek~~
 - ~~<http://www.hackyapp.com/> by [Elias Klughammer](https://github.com/eliaskg)~~
 - ~~<http://whimsyapps.com/hn/> by [James Dumay](https://github.com/i386)~~


### PR DESCRIPTION
This PR **does not** add any new list items.  It **does** do the following:

1. Put ~~Hacker Bar~~ in strikethrough since this app is no longer available.  See image below for what happens when you click the link.
2. Added a `(Not available in U.S.)` not to MackerNews because, well, it's not available in the U.S.

That's it!  Hope this is helpful.  Sorry about the master branch PR, but given the footprint of changes, thought it would be alright.

 > This is what you see when you try to access Hacker Bar:
 > 
 > <img width="1636" alt="Screen Shot 2020-04-02 at 7 37 25 PM" src="https://user-images.githubusercontent.com/4712768/78310372-c3564880-751b-11ea-9861-7f5b18aea6f8.png">
