### PR TITLE
add Hacker News Headlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ A collection of awesome [Hacker News](https://news.ycombinator.com/) apps, libra
 - [Hacker News Groups](https://github.com/antontarasenko/hacker-news-groups)
 - [Hacker News TLDR Podcast](https://open.spotify.com/show/3lGKG0r7A6DB25bz7ONkub?si=79e95c9d70de4c98)
 - [Hacker News Undocumented Features and Behaviors](https://github.com/minimaxir/hacker-news-undocumented)
+- [Hacker News Headlines](https://github.com/bodazhao/hacker-news-headlines)
 
 ## Contributing
 


### PR DESCRIPTION
Hi, I've always wanted a simple list of the daily best posts on HN but couldn't find a resource that does so, so I built one.

[Hacker News Headlines](https://hnhd.io/) is a clean, simple list of number 1 post on HN since day one. It's 

- simple (just a list)
- fast (static page)
- search-able
- actively maintained (project started a year ago)