### PR TITLE
Update Link to https://hnrss.github.io/

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ A collection of awesome [Hacker News](https://news.ycombinator.com/) apps, libra
 ### RSS/Atom Feeds
 
 - [Official RSS Feed](https://news.ycombinator.com/rss)
-- [Hacker News RSS](https://edavis.github.io/hnrss/)
+- [Hacker News RSS](https://hnrss.github.io/)
 - [HNapp](http://hnapp.com/)
 - [Hacker News RSS](https://hackernewsrss.com/)
 


### PR DESCRIPTION
The `https://edavis.github.io/hnrss/` now redirects to `https://hnrss.github.io/`