### PR TITLE
Add hn30

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ A collection of awesome [Hacker News](https://news.ycombinator.com/) apps, libra
 - [Hacker News for busy web developers](https://lessnews.dev/)
 - [hcker.news - Story and Best Comments Timeline ](http://hckrnews.com/)
 - [HCKR news](http://hckrnews.com/)
+- [hn30](https://hn30.yamanlabs.com)
 - [HN Cake Day](http://bemmu.github.io/hncakeday/)
 - [HN Games - Videogames made by the HN community](https://hackernews.games/)
 - [HN Hiring Mapped](http://gaganpreet.github.io/hn-hiring-mapped/src/web/)


### PR DESCRIPTION
hn30 shows the current top 30 Hacker News Posts on a tech blog-style interface. It also features summaries with Gemini AI for each story. 

Thank you for considering to add this project to the list. 