### PR TITLE
Add CheckHN

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ A collection of awesome [Hacker News](https://news.ycombinator.com/) apps, libra
 - [alt.hn](https://alt-hn.vercel.app/)
 - [ASCII Press](https://asciipress.brightmirror.co/)
 - [Brutalist Hacker News](https://brutalisthackernews.com)
+- [CheckHN](https://checkhn.ad-si.com/)
 - [Clean Hacker News](https://adriel.co.nz/news/)
 - [Full Hacker News](http://www.fullhn.com/)
 - [HackerComments](http://www.hackercomments.ai)


### PR DESCRIPTION
CheckHN is a checklist for reading the most popular Hacker News posts.