### PR TITLE
Add Helium MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ A collection of awesome [Hacker News](https://news.ycombinator.com/) apps, libra
 
 ## API Wrappers
 - [hnconnector](https://github.com/mfiro/hnconnector)
+- [Helium MCP](https://github.com/connerlambden/helium-mcp) — Real-time news with 37-dimension bias scoring, ML options pricing, and live market data. [Interactive demo](https://connerlambden.github.io/helium-news-explorer/) · [REST API](https://heliumtrades.com/mcp-page/)
 
 ## Contributing
 


### PR DESCRIPTION
Adds Helium MCP — 37-dim news bias scoring across 216 sources, ML options pricing, live market data. Interactive demos: https://connerlambden.github.io/helium-news-explorer/